### PR TITLE
Changed email delivery to inline to fix issues with SolidQueue in Heroku

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :solid_queue
+  config.active_job.queue_adapter = :inline
   config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
Changed active_job adapter to inline to fix issues with SolidQueue in Heroku. Emails now send synchronously. This is a temporary measure as the app has negligible traffic. Need to change to async adapter in the future.